### PR TITLE
possible flaky test

### DIFF
--- a/tests/unit/test_font.py
+++ b/tests/unit/test_font.py
@@ -15,11 +15,12 @@ def font_samples():
 def test_register_bad_font():
     assert not FontCore().register_font("foo", b"bar")
 
-
-def test_register_font_and_is_registered(font_samples):
+def test_not_registered():
     assert not FontCore().is_registered("LiberationSerif")
 
+def test_register_font_and_is_registered(font_samples):
     with open(os.path.join(font_samples, "LiberationSerif-Regular.ttf"), "rb+") as f:
         FontCore().register_font("LiberationSerif", f.read())
 
         assert FontCore().is_registered("LiberationSerif")
+


### PR DESCRIPTION
When I run pytest --flake-finder, this test gave me an error saying that font is already registered, so I think it is better to separate the test into two parts - one to test not registered and the other test registered. If some people run this tool again they won't get the error. that's why I opened this PR.