### PR TITLE
Fixed checkbox not checked in FormWrapper

### DIFF
--- a/PyPDFForm/filler.py
+++ b/PyPDFForm/filler.py
@@ -154,7 +154,7 @@ def simple_fill(
             key = get_widget_key(annot.get_object())
 
             widget = widgets.get(key)
-            if widget is None:
+            if widget is None or widget.value is None:
                 continue
 
             if isinstance(widget, Checkbox):
@@ -165,9 +165,9 @@ def simple_fill(
                 radio_button_tracker[key] += 1
                 if widget.value == radio_button_tracker[key] - 1:
                     simple_update_radio_value(annot)
-            elif isinstance(widget, Dropdown) and widget.value is not None:
+            elif isinstance(widget, Dropdown):
                 simple_update_dropdown_value(annot, widget)
-            elif isinstance(widget, Text) and widget.value:
+            elif isinstance(widget, Text):
                 simple_update_text_value(annot, widget)
 
             if flatten:

--- a/PyPDFForm/filler.py
+++ b/PyPDFForm/filler.py
@@ -8,10 +8,12 @@ from pypdf import PdfReader, PdfWriter
 from pypdf.generic import DictionaryObject
 
 from .constants import WIDGET_TYPES, Annots
-from .coordinate import (get_draw_checkbox_radio_coordinates,
-                         get_draw_sig_coordinates_resolutions,
-                         get_draw_text_coordinates,
-                         get_text_line_x_coordinates)
+from .coordinate import (
+    get_draw_checkbox_radio_coordinates,
+    get_draw_sig_coordinates_resolutions,
+    get_draw_text_coordinates,
+    get_text_line_x_coordinates,
+)
 from .font import checkbox_radio_font_size
 from .image import any_image_to_jpg
 from .middleware.checkbox import Checkbox
@@ -19,10 +21,14 @@ from .middleware.dropdown import Dropdown
 from .middleware.radio import Radio
 from .middleware.signature import Signature
 from .middleware.text import Text
-from .patterns import (simple_flatten_generic, simple_flatten_radio,
-                       simple_update_checkbox_value,
-                       simple_update_dropdown_value, simple_update_radio_value,
-                       simple_update_text_value)
+from .patterns import (
+    simple_flatten_generic,
+    simple_flatten_radio,
+    simple_update_checkbox_value,
+    simple_update_dropdown_value,
+    simple_update_radio_value,
+    simple_update_text_value,
+)
 from .template import get_widget_key, get_widgets_by_page
 from .utils import checkbox_radio_to_draw, stream_to_io
 from .watermark import create_watermarks_and_draw, merge_watermarks_with_pdf
@@ -151,8 +157,8 @@ def simple_fill(
             if widget is None:
                 continue
 
-            if type(widget) is Checkbox and widget.value is True:
-                simple_update_checkbox_value(annot)
+            if type(widget) is Checkbox:
+                simple_update_checkbox_value(annot, widget.value)
             elif isinstance(widget, Radio):
                 if key not in radio_button_tracker:
                     radio_button_tracker[key] = 0

--- a/PyPDFForm/filler.py
+++ b/PyPDFForm/filler.py
@@ -157,7 +157,7 @@ def simple_fill(
             if widget is None:
                 continue
 
-            if type(widget) is Checkbox:
+            if isinstance(widget, Checkbox):
                 simple_update_checkbox_value(annot, widget.value)
             elif isinstance(widget, Radio):
                 if key not in radio_button_tracker:

--- a/PyPDFForm/patterns.py
+++ b/PyPDFForm/patterns.py
@@ -100,11 +100,15 @@ BUTTON_STYLE_PATTERNS = [
 ]
 
 
-def simple_update_checkbox_value(annot: DictionaryObject) -> None:
+def simple_update_checkbox_value(annot: DictionaryObject, check: bool = False) -> None:
     """Patterns to update values for checkbox annotations."""
 
     for each in annot[AP][D]:  # noqa
-        if str(each) != Off:
+        if check and str(each) != Off:
+            annot[NameObject(AS)] = NameObject(each)
+            annot[NameObject(V)] = NameObject(each)
+            break
+        if not check and str(each) == Off:
             annot[NameObject(AS)] = NameObject(each)
             annot[NameObject(V)] = NameObject(each)
             break

--- a/PyPDFForm/patterns.py
+++ b/PyPDFForm/patterns.py
@@ -1,11 +1,31 @@
 # -*- coding: utf-8 -*-
 """Contains patterns used for identifying properties of widgets."""
 
-from pypdf.generic import (DictionaryObject, NameObject, NumberObject,
-                           TextStringObject)
+from pypdf.generic import DictionaryObject, NameObject, NumberObject, TextStringObject
 
-from .constants import (AP, AS, CA, DA, FT, MK, READ_ONLY, Btn, Ch, D, Ff, Off,
-                        Opt, Parent, Q, Sig, Subtype, T, Tx, V, Widget)
+from .constants import (
+    AP,
+    AS,
+    CA,
+    DA,
+    FT,
+    MK,
+    READ_ONLY,
+    Btn,
+    Ch,
+    D,
+    Ff,
+    Off,
+    Opt,
+    Parent,
+    Q,
+    Sig,
+    Subtype,
+    T,
+    Tx,
+    V,
+    Widget,
+)
 from .middleware.checkbox import Checkbox
 from .middleware.dropdown import Dropdown
 from .middleware.radio import Radio
@@ -86,6 +106,7 @@ def simple_update_checkbox_value(annot: DictionaryObject) -> None:
     for each in annot[AP][D]:  # noqa
         if str(each) != Off:
             annot[NameObject(AS)] = NameObject(each)
+            annot[NameObject(V)] = NameObject(each)
             break
 
 


### PR DESCRIPTION
fix for #558

So I've reverse engineered the value of the annotation when it was checked and not checked and I have found that you were missing the value of `/V`.

The value of annot in the base template:

```
{'/AP': {'/D': {'/Off': IndirectObject(19, 0, 139905065837776), '/Yes': IndirectObject(20, 0, 139905065837776)}, '/N': {'/Off': IndirectObject(22, 0, 139905065837776), '/Yes': IndirectObject(23, 0, 139905065837776)}}, '/AS': '/Off', '/F': 4, '/FT': '/Btn', '/MK': {'/BC': [0.0], '/BG': [1], '/CA': '4'}, '/P': IndirectObject(4, 0, 139905065837776), '/Rect': [358.874, 664.717, 377.354, 683.197], '/Subtype': '/Widget', '/T': 'check', '/Type': '/Annot', }
```

The value of the annot in a manually checked and saved file:
```
{'/AP': {'/D': {'/Off': IndirectObject(19, 0, 139905065837776), '/Yes': IndirectObject(20, 0, 139905065837776)}, '/N': {'/Off': IndirectObject(22, 0, 139905065837776), '/Yes': IndirectObject(23, 0, 139905065837776)}}, '/AS': '/Yes', '/F': 4, '/FT': '/Btn', '/MK': {'/BC': [0.0], '/BG': [1], '/CA': '4'}, '/P': IndirectObject(4, 0, 139905065837776), '/Rect': [358.874, 664.717, 377.354, 683.197], '/Subtype': '/Widget', '/T': 'check', '/Type': '/Annot', '/V': '/Yes'}
```

The value of the annot after checking it with your package:

```
{'/AP': {'/D': {'/Off': IndirectObject(19, 0, 139905065837776), '/Yes': IndirectObject(20, 0, 139905065837776)}, '/N': {'/Off': IndirectObject(22, 0, 139905065837776), '/Yes': IndirectObject(23, 0, 139905065837776)}}, '/AS': '/Yes', '/F': 4, '/FT': '/Btn', '/MK': {'/BC': [0.0], '/BG': [1], '/CA': '4'}, '/P': IndirectObject(4, 0, 139905065837776), '/Rect': [358.874, 664.717, 377.354, 683.197], '/Subtype': '/Widget', '/T': 'check', '/Type': '/Annot'
```

I've concluded that you had to put the `/V` (value I think) and this seems to work.

Also, I've added the option to uncheck a checkbox if you need to.

Best