### PR TITLE
fix: image conversion for other image modes (skip alpha band)

### DIFF
--- a/PyPDFForm/image.py
+++ b/PyPDFForm/image.py
@@ -42,8 +42,11 @@ def any_image_to_jpg(image_stream: bytes) -> bytes:
         return image_stream
 
     rgb_image = Image.new("RGB", image.size, (255, 255, 255))
-    rgb_image.paste(image, mask=image.split()[3])
-
+    if len(image.split()) == 4:
+      rgb_image.paste(image, mask=image.split()[3])
+    else:
+      rgb_image.paste(image)
+        
     with BytesIO() as _file:
         rgb_image.save(_file, format="JPEG")
         _file.seek(0)


### PR DESCRIPTION
pillow image modes: https://pillow.readthedocs.io/en/stable/handbook/concepts.html

In my case, i was dealing with a `P` mode image.  and got hit with `IndexError: tuple index out of range`. While the current operation is useful it's not needed for cases such as the one I faced. So we put it under a condition.

### All Submissions:

* [x] Have you followed the guidelines in the [developer guide](https://chinapandaman.github.io/PyPDFForm/dev_intro/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
