### PR TITLE
PPF-560 add pushbutton field, possibility to trasform it in image field

### DIFF
--- a/PyPDFForm/constants.py
+++ b/PyPDFForm/constants.py
@@ -5,6 +5,7 @@ from typing import Union
 
 from .middleware.checkbox import Checkbox
 from .middleware.dropdown import Dropdown
+from .middleware.image import Image
 from .middleware.pushbutton import Pushbutton
 from .middleware.radio import Radio
 from .middleware.signature import Signature
@@ -23,11 +24,17 @@ VERSION_IDENTIFIERS = [
 ]
 VERSION_IDENTIFIER_PREFIX = b"%PDF-"
 
-WIDGET_TYPES = Union[Text, Checkbox, Radio, Dropdown, Signature, Pushbutton]
+WIDGET_TYPES = Union[Text, Checkbox, Radio, Dropdown, Signature, Image, Pushbutton]
 
 DEPRECATION_NOTICE = "{} will be deprecated soon. Use {} instead."
 
 Annots = "/Annots"
+A = "/A"
+JS = "/JS"
+Type = "/Type"
+Action = "/Action"
+S = "/S"
+JavaScript = "/JavaScript"
 T = "/T"
 Rect = "/Rect"
 FT = "/FT"
@@ -69,6 +76,8 @@ DEFAULT_FONT_COLOR = (0, 0, 0)
 PREVIEW_FONT_COLOR = (1, 0, 0)
 
 NEW_LINE_SYMBOL = "\n"
+
+IMAGE_FIELD_IDENTIFIER = "event.target.buttonImportIcon();"
 
 DEFAULT_CHECKBOX_STYLE = "\u2713"
 DEFAULT_RADIO_STYLE = "\u25CF"

--- a/PyPDFForm/constants.py
+++ b/PyPDFForm/constants.py
@@ -5,7 +5,7 @@ from typing import Union
 
 from .middleware.checkbox import Checkbox
 from .middleware.dropdown import Dropdown
-from .middleware.image import Image
+from .middleware.pushbutton import Pushbutton
 from .middleware.radio import Radio
 from .middleware.signature import Signature
 from .middleware.text import Text
@@ -23,13 +23,11 @@ VERSION_IDENTIFIERS = [
 ]
 VERSION_IDENTIFIER_PREFIX = b"%PDF-"
 
-WIDGET_TYPES = Union[Text, Checkbox, Radio, Dropdown, Signature, Image]
+WIDGET_TYPES = Union[Text, Checkbox, Radio, Dropdown, Signature, Pushbutton]
 
 DEPRECATION_NOTICE = "{} will be deprecated soon. Use {} instead."
 
 Annots = "/Annots"
-A = "/A"
-JS = "/JS"
 T = "/T"
 Rect = "/Rect"
 FT = "/FT"
@@ -71,8 +69,6 @@ DEFAULT_FONT_COLOR = (0, 0, 0)
 PREVIEW_FONT_COLOR = (1, 0, 0)
 
 NEW_LINE_SYMBOL = "\n"
-
-IMAGE_FIELD_IDENTIFIER = "event.target.buttonImportIcon();"
 
 DEFAULT_CHECKBOX_STYLE = "\u2713"
 DEFAULT_RADIO_STYLE = "\u25CF"

--- a/PyPDFForm/filler.py
+++ b/PyPDFForm/filler.py
@@ -16,7 +16,7 @@ from .font import checkbox_radio_font_size
 from .image import any_image_to_jpg
 from .middleware.checkbox import Checkbox
 from .middleware.dropdown import Dropdown
-from .middleware.image import Image
+from .middleware.pushbutton import Pushbutton
 from .middleware.radio import Radio
 from .middleware.signature import Signature
 from .middleware.text import Text
@@ -53,7 +53,7 @@ def check_radio_handler(
 
 
 def signature_image_handler(
-    widget: dict, middleware: Union[Signature, Image], images_to_draw: list
+    widget: dict, middleware: Union[Signature, Pushbutton], images_to_draw: list
 ) -> bool:
     """Handles draw parameters for signature and image widgets."""
 
@@ -127,8 +127,8 @@ def fill(
                 to_draw, x, y, text_needs_to_be_drawn = check_radio_handler(
                     widget_dict, widgets[key], radio_button_tracker
                 )
-            elif isinstance(widgets[key], (Signature, Image)):
-                any_image_to_draw |= signature_image_handler(
+            elif isinstance(widgets[key], (Signature, Pushbutton)):
+                any_image_to_draw = signature_image_handler(
                     widget_dict, widgets[key], images_to_draw[page]
                 )
             else:

--- a/PyPDFForm/filler.py
+++ b/PyPDFForm/filler.py
@@ -130,7 +130,7 @@ def fill(
             elif isinstance(widgets[key], (Signature, Pushbutton)):
                 any_image_to_draw = signature_image_handler(
                     widget_dict, widgets[key], images_to_draw[page]
-                )
+                ) or any_image_to_draw
             else:
                 to_draw, x, y, text_needs_to_be_drawn = text_handler(
                     widget_dict, widgets[key]

--- a/PyPDFForm/middleware/image.py
+++ b/PyPDFForm/middleware/image.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Contains image field middleware."""
+
+from .signature import Signature
+
+
+class Image(Signature):
+    """A class to represent an image field widget."""

--- a/PyPDFForm/middleware/image.py
+++ b/PyPDFForm/middleware/image.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-"""Contains image field middleware."""
-
-from .signature import Signature
-
-
-class Image(Signature):
-    """A class to represent an image field widget."""

--- a/PyPDFForm/middleware/pushbutton.py
+++ b/PyPDFForm/middleware/pushbutton.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Contains Pushbutton middleware."""
+
+from .signature import Signature
+
+
+class Pushbutton(Signature):
+    """A class to represent a pushbutton widget."""

--- a/PyPDFForm/middleware/pushbutton.py
+++ b/PyPDFForm/middleware/pushbutton.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Contains Pushbutton middleware."""
 
-from .signature import Signature
+from .base import Widget
 
 
-class Pushbutton(Signature):
+class Pushbutton(Widget):
     """A class to represent a pushbutton widget."""

--- a/PyPDFForm/middleware/signature.py
+++ b/PyPDFForm/middleware/signature.py
@@ -36,8 +36,14 @@ class Signature(Widget):
     def stream(self) -> Union[bytes, None]:
         """Converts the value of the signature field image to a stream."""
 
-        return (
+        stream = (
             fp_or_f_obj_or_stream_to_stream(self.value)
             if self.value is not None
+            else None
+        )
+
+        return (
+            stream
+            if stream != b''
             else None
         )

--- a/PyPDFForm/patterns.py
+++ b/PyPDFForm/patterns.py
@@ -4,20 +4,23 @@
 from pypdf.generic import (DictionaryObject, NameObject, NumberObject,
                            TextStringObject)
 
-from .constants import (AP, AS, CA, DA, DV, FT, IMAGE_FIELD_IDENTIFIER, JS, MK,
-                        MULTILINE, READ_ONLY, A, Btn, Ch, Ff, N, Off, Opt,
+from .constants import (AP, AS, CA, DA, DV, FT, MK,
+                        MULTILINE, READ_ONLY, Btn, Ch, Ff, N, Off, Opt,
                         Parent, Q, Sig, T, Tx, V, Yes)
 from .middleware.checkbox import Checkbox
 from .middleware.dropdown import Dropdown
-from .middleware.image import Image
+from .middleware.pushbutton import Pushbutton
 from .middleware.radio import Radio
 from .middleware.signature import Signature
 from .middleware.text import Text
 
 WIDGET_TYPE_PATTERNS = [
     (
-        ({A: {JS: IMAGE_FIELD_IDENTIFIER}},),
-        Image,
+        (
+            {FT: Btn},
+            {Ff: 17},
+        ),
+        Pushbutton,
     ),
     (
         ({FT: Sig},),

--- a/PyPDFForm/patterns.py
+++ b/PyPDFForm/patterns.py
@@ -4,17 +4,22 @@
 from pypdf.generic import (DictionaryObject, NameObject, NumberObject,
                            TextStringObject)
 
-from .constants import (AP, AS, CA, DA, DV, FT, MK,
-                        MULTILINE, READ_ONLY, Btn, Ch, Ff, N, Off, Opt,
-                        Parent, Q, Sig, T, Tx, V, Yes)
+from .constants import (AP, AS, CA, DA, DV, FT, IMAGE_FIELD_IDENTIFIER, JS, MK,
+                        MULTILINE, READ_ONLY, A, Btn, Ch, Ff, N, Off, Opt,
+                        Parent, Q, Sig, T, Tx, V, Yes, Type, Action, S, JavaScript)
 from .middleware.checkbox import Checkbox
 from .middleware.dropdown import Dropdown
+from .middleware.image import Image
 from .middleware.pushbutton import Pushbutton
 from .middleware.radio import Radio
 from .middleware.signature import Signature
 from .middleware.text import Text
 
 WIDGET_TYPE_PATTERNS = [
+    (
+        ({A: {JS: IMAGE_FIELD_IDENTIFIER}},),
+        Image,
+    ),
     (
         (
             {FT: Btn},
@@ -141,6 +146,15 @@ def simple_update_text_value(annot: DictionaryObject, widget: Text) -> None:
         annot[NameObject(V)] = TextStringObject(widget.value)
         annot[NameObject(AP)] = TextStringObject(widget.value)
 
+
+def simple_set_image_field(annot: DictionaryObject) -> None:
+    """Patterns to set for an image field."""
+
+    annot[NameObject(A)] = DictionaryObject({
+        NameObject(Type): NameObject(Action),
+        NameObject(S): NameObject(JavaScript),
+        NameObject(JS): TextStringObject(IMAGE_FIELD_IDENTIFIER),
+    })
 
 def simple_flatten_radio(annot: DictionaryObject) -> None:
     """Patterns to flatten checkbox annotations."""

--- a/PyPDFForm/template.py
+++ b/PyPDFForm/template.py
@@ -14,6 +14,8 @@ from .font import (adjust_paragraph_font_size, adjust_text_field_font_size,
                    auto_detect_font, get_text_field_font_color,
                    get_text_field_font_size, text_field_font_size)
 from .middleware.checkbox import Checkbox
+from .middleware.pushbutton import Pushbutton
+from .middleware.image import Image
 from .middleware.dropdown import Dropdown
 from .middleware.radio import Radio
 from .middleware.text import Text
@@ -108,6 +110,13 @@ def dropdown_to_text(dropdown: Dropdown) -> Text:
             if dropdown.value < len(dropdown.choices)
             else ""
         )
+
+    return result
+
+def pushbutton_to_image(pushbutton: Pushbutton) -> Image:
+    """Converts a dropdown widget to a text widget."""
+
+    result = Image(pushbutton.name)
 
     return result
 

--- a/PyPDFForm/utils.py
+++ b/PyPDFForm/utils.py
@@ -139,7 +139,7 @@ def check_feature_flags(value: int, bits: int|tuple) -> bool:
         bits = (bits,)
 
     for bit in bits:
-        if value << (bit - 1):
+        if value & 2**(bit - 1):
             return True
 
     return False

--- a/PyPDFForm/utils.py
+++ b/PyPDFForm/utils.py
@@ -9,7 +9,7 @@ from pypdf.generic import DictionaryObject
 
 from .constants import (BUTTON_STYLES, DEFAULT_CHECKBOX_STYLE, DEFAULT_FONT,
                         DEFAULT_FONT_COLOR, DEFAULT_FONT_SIZE,
-                        DEFAULT_RADIO_STYLE, PREVIEW_FONT_COLOR, WIDGET_TYPES)
+                        DEFAULT_RADIO_STYLE, PREVIEW_FONT_COLOR, WIDGET_TYPES, Ff)
 from .middleware.checkbox import Checkbox
 from .middleware.radio import Radio
 from .middleware.text import Text
@@ -122,7 +122,9 @@ def find_pattern_match(pattern: dict, widget: Union[dict, DictionaryObject]) -> 
             ):
                 result = find_pattern_match(pattern[key], value)
             else:
-                if isinstance(pattern[key], tuple):
+                if key == Ff:
+                    result = check_feature_flags(value, pattern[key])
+                elif isinstance(pattern[key], tuple):
                     result = value in pattern[key]
                 else:
                     result = pattern[key] == value
@@ -130,6 +132,17 @@ def find_pattern_match(pattern: dict, widget: Union[dict, DictionaryObject]) -> 
             return result
     return False
 
+def check_feature_flags(value: int, bits: int|tuple) -> bool:
+    """Checks if a int value has a bit set """
+
+    if not isinstance(bits, tuple):
+        bits = (bits,)
+
+    for bit in bits:
+        if value << (bit - 1):
+            return True
+
+    return False
 
 def traverse_pattern(
     pattern: dict, widget: Union[dict, DictionaryObject]

--- a/PyPDFForm/utils.py
+++ b/PyPDFForm/utils.py
@@ -139,10 +139,10 @@ def check_feature_flags(value: int, bits: int|tuple) -> bool:
         bits = (bits,)
 
     for bit in bits:
-        if value & 2**(bit - 1):
-            return True
+        if not (value & 2**(bit - 1)):
+            return False
 
-    return False
+    return True
 
 def traverse_pattern(
     pattern: dict, widget: Union[dict, DictionaryObject]

--- a/tests/scenario/test_existed.py
+++ b/tests/scenario/test_existed.py
@@ -3,6 +3,7 @@
 import os
 
 from PyPDFForm import PdfWrapper
+from PyPDFForm.middleware import pushbutton
 
 
 def test_illinois_gun_bill_of_sale(existed_pdf_directory, request):
@@ -189,4 +190,4 @@ def test_illinois_real_estate_power_of_attorney_form(existed_pdf_directory, requ
 def test_clear_form_button_not_checkbox(existed_pdf_directory):
     obj = PdfWrapper(os.path.join(existed_pdf_directory, "ds11_pdf.pdf"))
 
-    assert "Clear" not in obj.widgets
+    assert "Clear" in obj.widgets and isinstance(obj.widgets["Clear"], pushbutton.Pushbutton)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in the [developer guide](https://chinapandaman.github.io/PyPDFForm/dev_intro/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?
(I run pylint locally)

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
(I don't really know where to add an explanation for this, recognizing all pushbuttons as such instead of recognizing only a subset as image fields)
* [ ] Have you written new tests for your core changes, as applicable?
(I don't know if there's a need for new tests, I modified some of them to correctly run with these changes)
* [x] Have you successfully ran tests with your changes locally?

Basically this PR is based on [my last comment on the issue](https://github.com/chinapandaman/PyPDFForm/issues/560#issuecomment-2376122166) , it removes the special image field and treats all pushbuttons equally, with the possibility to set an image to them