### PR TITLE
PPF-1209: Fixed keyerror with fallback, added test

### DIFF
--- a/PyPDFForm/patterns.py
+++ b/PyPDFForm/patterns.py
@@ -294,12 +294,7 @@ def get_text_field_multiline(annot: DictionaryObject) -> bool:
         try:
             parent_obj = annot[NameObject(Parent)]
             return bool(
-                int(
-                    parent_obj[NameObject(Ff)]
-                    if Ff in parent_obj
-                    else 0
-                )
-                & MULTILINE
+                int(parent_obj[NameObject(Ff)] if Ff in parent_obj else 0) & MULTILINE
             )
         except (KeyError, AttributeError, TypeError):
             return False

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1206,9 +1206,11 @@ def test_get_text_field_multiline_with_keyerror_in_parent():
     when the parent reference cannot be resolved properly.
     """
     from unittest.mock import MagicMock, patch
+
     from pypdf.generic import DictionaryObject, IndirectObject, NameObject
-    from PyPDFForm.patterns import get_text_field_multiline
+
     from PyPDFForm.constants import Parent
+    from PyPDFForm.patterns import get_text_field_multiline
 
     annot = DictionaryObject()
 


### PR DESCRIPTION
This PR fixes Issue PPF-1209 by falling back to False for multiline. This prevents the PdfWrapper class instantiation from crashing.


### All Submissions:

* [x] Have you followed the guidelines in the [developer guide](https://chinapandaman.github.io/PyPDFForm/dev_intro/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
