### PR TITLE
Revert "PPF-1237: appearance stream post processing only happens for PyPDFForm created fields for now"

### DIFF
--- a/PyPDFForm/ap.py
+++ b/PyPDFForm/ap.py
@@ -138,14 +138,7 @@ def ap_processing_reportlab_text_field_alignment(
     Returns:
         bool: True if the appearance stream was modified, False otherwise.
     """
-    if any(
-        [
-            not widget.created_by_pypdfform,
-            not isinstance(widget, Text),
-            not widget.alignment,
-            not widget.value,
-        ]
-    ):
+    if (not widget.alignment) or (not widget.value):
         return False
 
     ap_stream = annot[AP][N].get_data()

--- a/PyPDFForm/middleware/base.py
+++ b/PyPDFForm/middleware/base.py
@@ -46,7 +46,6 @@ class Widget:
         self.readonly: bool = None
         self.required: bool = None
         self.hooks_to_trigger: list = []
-        self.created_by_pypdfform: bool = False
 
     def __setattr__(self, name: str, value: Any) -> None:
         """

--- a/PyPDFForm/wrapper.py
+++ b/PyPDFForm/wrapper.py
@@ -594,7 +594,6 @@ class PdfWrapper:
         for widget in widgets:
             for k, v in widget.hook_params:
                 self.widgets[widget.name].__setattr__(k, v)
-            self.widgets[widget.name].created_by_pypdfform = True
 
         return self
 
@@ -697,8 +696,6 @@ class PdfWrapper:
         self._init_helper()
         for k, v in hook_params:
             self.widgets[name].__setattr__(k, v)
-
-        self.widgets[name].created_by_pypdfform = True
 
         return self
 

--- a/tests/test_bulk_create_fields.py
+++ b/tests/test_bulk_create_fields.py
@@ -209,9 +209,6 @@ def test_bulk_create_fields_stress_max(pdf_samples, request):
             obj += PdfWrapper(os.path.join(pdf_samples, "dummy.pdf"))
         obj.bulk_create_fields(fields)
 
-        for each in obj.widgets.values():
-            assert each.created_by_pypdfform
-
         request.config.results["expected_path"] = expected_path
         request.config.results["stream"] = obj.read()
 

--- a/tests/test_create_widget.py
+++ b/tests/test_create_widget.py
@@ -368,12 +368,6 @@ def test_create_text_default(template_stream, pdf_samples, request):
         )
         assert obj.schema["properties"]["foo"]["type"] == "string"
 
-        for k, v in obj.widgets.items():
-            if k != "foo":
-                assert not v.created_by_pypdfform
-            else:
-                assert v.created_by_pypdfform
-
         request.config.results["expected_path"] = expected_path
         request.config.results["stream"] = obj.read()
 


### PR DESCRIPTION
Reverts chinapandaman/PyPDFForm#1238