### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/chinapandaman/PyPDFForm/security/code-scanning/8](https://github.com/chinapandaman/PyPDFForm/security/code-scanning/8)

The best way to fix the problem is to add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. Since the workflow shown only checks out code, installs dependencies, and runs tests (without writing to pull requests, issues, or other repository resources), the minimal required permission is `contents: read`. This can be set either at the root of the workflow file so it applies to all jobs, or within the job itself. The most maintainable and clear approach is to set `permissions` at the workflow root (immediately after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No further imports or changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
