### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -1,4 +1,6 @@
 name: Linting
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/chinapandaman/PyPDFForm/security/code-scanning/7](https://github.com/chinapandaman/PyPDFForm/security/code-scanning/7)

To fix the problem, add a `permissions` key at the top-level of the workflow file or within the individual job definition. Since this is a general linting workflow (no artifact upload, issue comments, or PR write actions), the minimal permission required is `contents: read`. This key should be placed directly below the `name:` field (for workflow-wide scope), or just under the job name (for per-job scope). The best practice is to keep it at the workflow (root) level unless individual jobs require different scopes. This change requires adding the permission block under the `name:` line at the top of `.github/workflows/python-linting.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
