### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,5 +1,8 @@
 name: Nightly Build
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:
@@ -7,6 +10,9 @@ on:
 
 jobs:
   close-staled-issues:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/chinapandaman/PyPDFForm/security/code-scanning/6](https://github.com/chinapandaman/PyPDFForm/security/code-scanning/6)

To fix the problem, we should set explicit `permissions` in the workflow. The ideal approach is to add `permissions: contents: read` at the top of the workflow file so all jobs default to read-only permissions (the minimal needed for code checkout). If any job needs more (e.g., the `close-staled-issues` job likely needs `issues: write` and `contents: read`), override the `permissions` field for that job only.  
The required change is to:  
1. Add a block at line 2-3 like:
   ```
   permissions:
     contents: read
   ```
2. For the `close-staled-issues` job, add a `permissions` field with the required scopes (e.g., `contents: read`, `issues: write`).
No dependency changes or code logic changes are required, only YAML permission specification in `.github/workflows/nightly-build.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
