### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,4 +1,6 @@
 name: Bump Version
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/chinapandaman/PyPDFForm/security/code-scanning/4](https://github.com/chinapandaman/PyPDFForm/security/code-scanning/4)

To fix the problem, explicitly specify a `permissions` block at either the workflow root or job level to enforce the principle of least privilege. Since the workflow includes steps that commit and push changes (which require write access to the repository contents), the job needs `"contents: write"`. Add this block at the workflow root (top-level), so all jobs inherit this setting, unless a job has a more granular requirement. Edit `.github/workflows/bump-version.yml` to insert the block after the `name: Bump Version` line and before `on:` for maximum clarity and best practice.

**Needed changes:**  
- Add a block:  
  ```yaml
  permissions:
    contents: write
  ```
- No additional methods, imports, or external definitions are required; it's purely a YAML configuration edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
