### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,4 +1,6 @@
 name: Deploy Docs
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/chinapandaman/PyPDFForm/security/code-scanning/2](https://github.com/chinapandaman/PyPDFForm/security/code-scanning/2)

To fix the problem, the workflow YAML should include a `permissions` block at either the root or job level to specify the minimum necessary privileges required by the actions within the job. Given that the job is named `deploy` and runs `mkdocs gh-deploy --force --clean --verbose`, which needs to push to the `gh-pages` branch, the job needs `contents: write` permission in order to push to the repository. The safest fix is to add:
```yaml
permissions:
  contents: write
```
to the workflow (at the top level, after `name`, before `on`).  
This restricts the `GITHUB_TOKEN` to only have write access to repository contents, which is both minimal and necessary for documentation deployment.  
**File/region to change:** Add the `permissions:` block at the root of `.github/workflows/deploy-docs.yml`, immediately after the `name` key and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
