### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,6 @@
 name: Create Release
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/chinapandaman/PyPDFForm/security/code-scanning/1](https://github.com/chinapandaman/PyPDFForm/security/code-scanning/1)

The recommended fix is to add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` permissions to the minimal necessary. This should be added at the root level of the workflow (immediately after `name:` and before `on:`) to apply to all jobs, unless any job needs different permissions. Typically, workflows that create releases require at least `contents: write` permission. Therefore, set `permissions: contents: write`, unless there's knowledge that only read access is needed—however, creating or updating a release through the API usually requires write access.

**How to fix:**
- Add the following block immediately after the `name:` line and before the `on:` line in `.github/workflows/create-release.yml`:
  ```yaml
  permissions:
    contents: write
  ```
- No need to add imports, definitions, or additional methods—just the YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
