### PR TITLE
PPF-1679: expose page_number on middleware widgets

### DIFF
--- a/PyPDFForm/lib/middleware/base.py
+++ b/PyPDFForm/lib/middleware/base.py
@@ -62,6 +62,7 @@ class Widget:
         self.hooks_to_trigger: list = []
 
         # coordinate & dimension
+        self.page_number: Optional[int] = None
         self.x: Optional[float | List[float]] = None
         self.y: Optional[float | List[float]] = None
         self.width: Optional[float | List[float]] = None

--- a/PyPDFForm/lib/template.py
+++ b/PyPDFForm/lib/template.py
@@ -73,15 +73,15 @@ def build_widgets(
     """
     results = {}
 
-    for widgets in get_widgets_by_page(pdf_stream).values():
+    for page_num, widgets in get_widgets_by_page(pdf_stream).items():
         for widget in widgets:
-            _process_widget(widget, use_full_widget_name, results)
+            _process_widget(widget, use_full_widget_name, results, page_num)
 
     return results
 
 
 def _process_widget(
-    widget: dict, use_full_widget_name: bool, results: Dict[str, WIDGET_TYPES]
+    widget: dict, use_full_widget_name: bool, results: Dict[str, WIDGET_TYPES], page_number: int
 ) -> None:
     """
     Processes a single widget and adds it to the results dictionary.
@@ -90,11 +90,12 @@ def _process_widget(
         widget (dict): The widget dictionary from the PDF.
         use_full_widget_name (bool): Whether to use the full widget name.
         results (Dict[str, WIDGET_TYPES]): The dictionary of widgets being built.
+        page_number (int): The 1-indexed page number the widget appears on.
     """
     key = get_widget_key(widget, use_full_widget_name)
     _widget = construct_widget(widget, key)
     if _widget is not None:
-        _populate_common_properties(widget, _widget)
+        _populate_common_properties(widget, _widget, page_number)
 
         if isinstance(_widget, Text):
             _populate_text_properties(widget, _widget)
@@ -111,15 +112,19 @@ def _process_widget(
             results[key] = _widget
 
 
-def _populate_common_properties(widget: dict, _widget: WIDGET_TYPES) -> None:
+def _populate_common_properties(
+    widget: dict, _widget: WIDGET_TYPES, page_number: int
+) -> None:
     """
     Populates common properties for a widget.
 
     Args:
         widget (dict): The widget dictionary from the PDF.
         _widget (WIDGET_TYPES): The widget object to populate.
+        page_number (int): The 1-indexed page number the widget appears on.
     """
     # widget property extractions don't trigger hooks in this function
+    _widget.__dict__["page_number"] = page_number
     _widget.__dict__["tooltip"] = extract_widget_property(
         widget, WIDGET_DESCRIPTION_PATTERNS, None, str
     )

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -751,31 +751,37 @@ def test_widget_coord_resolution():
     assert obj.widgets["text"].y == 100
     assert obj.widgets["text"].width == 200
     assert obj.widgets["text"].height == 150
+    assert obj.widgets["text"].page_number == 1
 
     assert obj.widgets["check"].x == 150
     assert obj.widgets["check"].y == 200
     assert obj.widgets["check"].width == 60
     assert obj.widgets["check"].height == 60
+    assert obj.widgets["check"].page_number == 1
 
     assert obj.widgets["radio"].x == [400, 500, 600]
     assert obj.widgets["radio"].y == [450, 550, 650]
     assert obj.widgets["radio"].width == 10
     assert obj.widgets["radio"].height == 10
+    assert obj.widgets["radio"].page_number == 1
 
     assert obj.widgets["dropdown"].x == 400
     assert obj.widgets["dropdown"].y == 100
     assert obj.widgets["dropdown"].width == 250
     assert obj.widgets["dropdown"].height == 200
+    assert obj.widgets["dropdown"].page_number == 1
 
     assert obj.widgets["image"].x == 300
     assert obj.widgets["image"].y == 400
     assert obj.widgets["image"].width == 400
     assert obj.widgets["image"].height == 300
+    assert obj.widgets["image"].page_number == 1
 
     assert obj.widgets["signature"].x == 500
     assert obj.widgets["signature"].y == 600
     assert obj.widgets["signature"].width == 600
     assert obj.widgets["signature"].height == 500
+    assert obj.widgets["signature"].page_number == 1
 
 
 def test_hidden_text_check(template_stream, pdf_samples, request):


### PR DESCRIPTION
completes https://github.com/chinapandaman/PyPDFForm/issues/1680

Add a page_number attribute to Widget so callers can inspect which 1-indexed page a form field lives on via PdfWrapper.widgets.

The page data was already available in get_widgets_by_page() but discarded when iterating. Thread it through build_widgets() → _process_widget() → _populate_common_properties() where it is set alongside the other positional properties (x, y, width, height).

```python
from PyPDFForm import PdfWrapper, RawElements

pdf = PdfWrapper("pdf_samples/test_annotate.pdf")
widget = pdf.widgets['test']

raw_text = RawElements.RawText(
    text="my annotation text",
    page_number=widget.page_number, ## this is the new value
    x=widget.x,
    y=(widget.y + 20)
)

pdf.draw([raw_text])
pdf.write("annotated.pdf")
```
results:
<img width="530" height="252" alt="image" src="https://github.com/user-attachments/assets/8230814b-d6bd-45f4-8035-c6718ae49ea1" />

### All Submissions:

* [ ] Have you followed the guidelines in the [developer guide](https://chinapandaman.github.io/PyPDFForm/latest/dev_intro/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?  - I the same tests fail on master for me.
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
